### PR TITLE
fix: Update aifc imports for Python 3.13 compatibility

### DIFF
--- a/speech_recognition/__init__.py
+++ b/speech_recognition/__init__.py
@@ -4,7 +4,12 @@
 
 from __future__ import annotations
 
-import aifc
+import sys
+if sys.version_info >= (3, 13):
+    import standard_aifc as aifc
+else:
+    import aifc
+    
 import audioop
 import base64
 import collections

--- a/speech_recognition/audio.py
+++ b/speech_recognition/audio.py
@@ -1,4 +1,9 @@
-import aifc
+import sys
+if sys.version_info >= (3, 13):
+    import standard_aifc as aifc
+else:
+    import aifc
+    
 import audioop
 import io
 import os


### PR DESCRIPTION
# Fix aifc imports for Python 3.13 compatibility

## Description
Updates the aifc imports to handle Python 3.13's deprecation of the built-in `aifc` module by using `standard-aifc` when running on Python 3.13 or higher.

## Changes
- Modified `__init__.py` and `audio.py` to use version-specific imports
- Uses `standard-aifc` for Python 3.13+ while maintaining backwards compatibility
- Works with existing conditional dependencies in setup.py

## Testing
- Tested on Python 3.13
- Resolves the deprecation warning: